### PR TITLE
fix(events): use proper key

### DIFF
--- a/Divergences of Darkness Fan Fork/events/MOD Italy - 1242XX.txt
+++ b/Divergences of Darkness Fan Fork/events/MOD Italy - 1242XX.txt
@@ -1446,7 +1446,7 @@ country_event = { #Republican Victory -Conservative Coup
 	}
 	
 	option = { 	
-	name = "TUS10.A" #Commons victory
+	name = "TUS10.B" #Commons victory
 	any_country = {
 			limit = { 
 			tag = PRV


### PR DESCRIPTION
this event refers to the victory of the Republicans in the Etrurian 1838
election, unfortunately it used the wrong key so both options would be
the same (see image attached to the GitHub PR)

![image](https://user-images.githubusercontent.com/30738253/153302397-041ebd2e-379f-4afc-b0a2-6bc491dde59b.png)

with this change the key should now read: "The Republicans crush the
coup"
